### PR TITLE
Exercise save entry

### DIFF
--- a/AndroidProject/Biometrix/biometrixApp/biometrixApp.iml
+++ b/AndroidProject/Biometrix/biometrixApp/biometrixApp.iml
@@ -65,28 +65,21 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/coverage-instrumented-classes" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/debug" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex-cache" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/appcompat-v7/23.1.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/design/23.1.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/recyclerview-v7/23.1.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-v4/23.1.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jacoco" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/javaResources" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/libs" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/lint" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/ndk" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/proguard" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/tmp" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
@@ -94,9 +87,9 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" exported="" name="recyclerview-v7-23.1.0" level="project" />
     <orderEntry type="library" exported="" name="jtds-1.3.1" level="project" />
-    <orderEntry type="library" exported="" name="support-annotations-23.1.0" level="project" />
-    <orderEntry type="library" exported="" name="appcompat-v7-23.1.0" level="project" />
-    <orderEntry type="library" exported="" name="design-23.1.0" level="project" />
     <orderEntry type="library" exported="" name="support-v4-23.1.0" level="project" />
+    <orderEntry type="library" exported="" name="design-23.1.0" level="project" />
+    <orderEntry type="library" exported="" name="appcompat-v7-23.1.0" level="project" />
+    <orderEntry type="library" exported="" name="support-annotations-23.1.0" level="project" />
   </component>
 </module>

--- a/AndroidProject/Biometrix/biometrixApp/src/main/java/com/rocket/biometrix/ExerciseEntry.java
+++ b/AndroidProject/Biometrix/biometrixApp/src/main/java/com/rocket/biometrix/ExerciseEntry.java
@@ -1,5 +1,6 @@
 package com.rocket.biometrix;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
@@ -17,14 +18,19 @@ import android.widget.Toast;
 
 public class ExerciseEntry extends AppCompatActivity implements AdapterView.OnItemSelectedListener {
 
-    Spinner minuteSpinner;
-    boolean toasted = false; //Used to display encouraging messages ONCE in minuteSpinner.
-
     public static TextView timeTV; //Used by the DateTimePopulateTextView in the onCreate event
     public static TextView dateTV;
 
     String minSelected; //string to save minutes exercised spinner result
     String typeSelected; //string to save type of exercise selected in the radio 'bubble' buttons
+
+    Spinner minuteSpinner;
+    boolean toasted = false; //Used to display encouraging messages ONCE in minuteSpinner.
+    //To avoid 'hard coded' strings...These are implemented in the minuteSpinners listener in the onCreate event
+    String lowestSpinnerValueThreshold = "5"; //5 minutes
+    String lowSpinnerValueThreshold = "10"; //10 minutes (idea is to encourage user to exercise more but still celebrate their 'baby' gains)
+    String lowSpinnerMessage = "Keep it up :)"; //The encouraging message
+    String highSpinnerMessage = "Nice!"; //The BEST message users strive for
 
 
     @Override
@@ -56,14 +62,14 @@ public class ExerciseEntry extends AppCompatActivity implements AdapterView.OnIt
                 //Set string
                 minSelected = parentView.getItemAtPosition(position).toString();
 
-                if (minSelected.equals("5") || minSelected.equals("10")) {
+                if (minSelected.equals(lowestSpinnerValueThreshold) || minSelected.equals(lowSpinnerValueThreshold)) {
                     if (!toasted) {
-                        Toast.makeText(getApplicationContext(), "Keep it up :)", Toast.LENGTH_LONG).show();
+                        Toast.makeText(getApplicationContext(), lowSpinnerMessage, Toast.LENGTH_LONG).show();
                         toasted = true;
                     }
                 } else {
                     if (!toasted) {
-                        Toast.makeText(getApplicationContext(), "Nice!", Toast.LENGTH_LONG).show();
+                        Toast.makeText(getApplicationContext(), highSpinnerMessage, Toast.LENGTH_LONG).show();
                         toasted = true;
                     }
                 }
@@ -143,6 +149,27 @@ public class ExerciseEntry extends AppCompatActivity implements AdapterView.OnIt
 
                 //Filling notes string
                 String notesString = GetStringFromEditText(R.id.ex_notes);
+
+                //Make string array to hold all the strings extracted from the user's input on this entry activity
+                String[] exerciseEntryData = {titleString,dateString,timeString,repsString,weightString,notesString};
+
+                //Put string array that has all the entries data points in it into a Bundle.
+                Bundle exerciseEntryBundle = new Bundle();
+                exerciseEntryBundle.putStringArray("exEntBundKey",exerciseEntryData);
+
+
+//                //TODO:Recieve intent extras from parent. Change the old String array to the newly filled string array; then put extra BACK IN and set result to OK w/ error checking.
+//                String parentExerciseEntryData;
+//
+//                    Bundle extras = getIntent().getExtras();
+//                    if(extras == null) {
+//                        parentExerciseEntryData= null;
+//                    } else {
+//                        parentExerciseEntryData= extras.getString("key");
+//                    }
+
+
+                //TODO: SQLite calls to LocalStorageAccess which will have to be made more abstract first since it's hardcoded now.
 
                 //Kill this thread, User will still have exercise main page open.
                 finish();

--- a/AndroidProject/Biometrix/biometrixApp/src/main/java/com/rocket/biometrix/ExerciseEntry.java
+++ b/AndroidProject/Biometrix/biometrixApp/src/main/java/com/rocket/biometrix/ExerciseEntry.java
@@ -1,6 +1,5 @@
 package com.rocket.biometrix;
 
-import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
@@ -24,8 +23,8 @@ public class ExerciseEntry extends AppCompatActivity implements AdapterView.OnIt
     public static TextView timeTV; //Used by the DateTimePopulateTextView in the onCreate event
     public static TextView dateTV;
 
-    String min_selected; //string to save minutes exercised spinner result
-    String type_selected; //string to save type of exercise selected in the radio 'bubble' buttons
+    String minSelected; //string to save minutes exercised spinner result
+    String typeSelected; //string to save type of exercise selected in the radio 'bubble' buttons
 
 
     @Override
@@ -55,9 +54,9 @@ public class ExerciseEntry extends AppCompatActivity implements AdapterView.OnIt
                     return;
                 }
                 //Set string
-                min_selected = parentView.getItemAtPosition(position).toString();
+                minSelected = parentView.getItemAtPosition(position).toString();
 
-                if (min_selected.equals("5") || min_selected.equals("10")) {
+                if (minSelected.equals("5") || minSelected.equals("10")) {
                     if (!toasted) {
                         Toast.makeText(getApplicationContext(), "Keep it up :)", Toast.LENGTH_LONG).show();
                         toasted = true;
@@ -88,22 +87,22 @@ public class ExerciseEntry extends AppCompatActivity implements AdapterView.OnIt
                     case R.id.ex_rb_a:
                         //Extract CharSequences from UI and convert them to string array
                         final RadioButton ETa1 = (RadioButton) findViewById(R.id.ex_rb_a);
-                        type_selected = ETa1.getText().toString();
+                        typeSelected = ETa1.getText().toString();
                         break;
 
                     case R.id.ex_rb_b:
                         final RadioButton ETa2 = (RadioButton) findViewById(R.id.ex_rb_b);
-                        type_selected = ETa2.getText().toString();
+                        typeSelected = ETa2.getText().toString();
                         break;
 
                     case R.id.ex_rb_c:
                         final RadioButton ETa3 = (RadioButton) findViewById(R.id.ex_rb_c);
-                        type_selected = ETa3.getText().toString();
+                        typeSelected = ETa3.getText().toString();
                         break;
 
                     case R.id.ex_rb_d:
                         final RadioButton ETa4 = (RadioButton) findViewById(R.id.ex_rb_d);
-                        type_selected = ETa4.getText().toString();
+                        typeSelected = ETa4.getText().toString();
                         break;
 
                 }
@@ -126,10 +125,24 @@ public class ExerciseEntry extends AppCompatActivity implements AdapterView.OnIt
         //Saves entry to SQLlite DB using LocalStorageAccess
         //And, Adds this exercise to the 'plan' if it needs to be added
         //Lastly, it closes up the entry activity.
-        Button addNewEntry = (Button) findViewById(R.id.ex_b_done);
-        addNewEntry.setOnClickListener(new View.OnClickListener() {
+        Button ExerciseEntryDone = (Button) findViewById(R.id.ex_b_done);
+        ExerciseEntryDone.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
+                //Filling a string that holds title
+                String titleString = GetStringFromEditText(R.id.ex_title);
 
+                //Filling date and time strings for bundle's string array
+                String dateString = dateTV.getText().toString();
+                String timeString = timeTV.getText().toString();
+
+                //Filling reps string
+                String repsString = GetStringFromEditText(R.id.ex_et_reps);
+
+                //Filling weight string from its editText found @content_exercise_entry.xml
+                String weightString = GetStringFromEditText(R.id.ex_et_weight);
+
+                //Filling notes string
+                String notesString = GetStringFromEditText(R.id.ex_notes);
 
                 //Kill this thread, User will still have exercise main page open.
                 finish();
@@ -146,6 +159,27 @@ public class ExerciseEntry extends AppCompatActivity implements AdapterView.OnIt
     @Override
     public void onNothingSelected(AdapterView<?> parent) {
         //To please the cruel mistress Android Studio...
+    }
+
+    //Function given an <<EditText>> resource ID (R.id.ex_et_weight) will return its text contents as a string.
+    //Soft error handling will just mess up the returned string if you gave a bad id, not crash the app.
+    public String GetStringFromEditText(int id)
+    {
+        String endResult = "ERROR in GetStringFromEditText: Resource ID does not exist";
+        //0 is always an invalid resource. And if a view can't be found by its ID, findViewById returns null
+        //http://developer.android.com/reference/android/content/res/Resources.html#getIdentifier%28java.lang.String,%20java.lang.String,%20java.lang.String%29
+        //http://developer.android.com/reference/android/app/Activity.html#findViewById%28int%29
+        if (id != 0) {
+            if (findViewById(id) != null)
+            try {
+                final EditText et = (EditText) findViewById(id);
+                endResult = et.getText().toString();
+            }//end try
+            catch (IllegalArgumentException |  ClassCastException exceptionName) {
+                endResult = "ERROR in GetStringFromEditText: try block";
+            }
+        }
+        return endResult;
     }
 
     //Getters and Setters NOT USED CURRENTLY

--- a/AndroidProject/Biometrix/biometrixApp/src/main/java/com/rocket/biometrix/ExerciseEntry.java
+++ b/AndroidProject/Biometrix/biometrixApp/src/main/java/com/rocket/biometrix/ExerciseEntry.java
@@ -141,6 +141,10 @@ public class ExerciseEntry extends AppCompatActivity implements AdapterView.OnIt
                 String dateString = dateTV.getText().toString();
                 String timeString = timeTV.getText().toString();
 
+                //Cleaning date and time strings (I know what you're thinking, why not test the buffer to determine where the 1st number occurs to avoid using magic numbers? Not worth it is my opinion.)
+                dateString = removeChars(dateString, 12); //Date:_Fri,__ = 12 characters.
+                timeString = removeChars(timeString, 7); //Time:__ = 7 characters
+
                 //Filling reps string
                 String repsString = GetStringFromEditText(R.id.ex_et_reps);
 
@@ -151,7 +155,7 @@ public class ExerciseEntry extends AppCompatActivity implements AdapterView.OnIt
                 String notesString = GetStringFromEditText(R.id.ex_notes);
 
                 //Make string array to hold all the strings extracted from the user's input on this entry activity
-                String[] exerciseEntryData = {titleString,dateString,timeString,repsString,weightString,notesString};
+                String[] exerciseEntryData = {titleString,dateString,timeString,minSelected,typeSelected,notesString};
 
                 //Put string array that has all the entries data points in it into a Bundle. This bundle is for future extensibility it is NOT for the parent class.
                 Bundle exerciseEntryBundle = new Bundle();
@@ -213,6 +217,20 @@ public class ExerciseEntry extends AppCompatActivity implements AdapterView.OnIt
             }
         }
         return endResult;
+    }
+
+
+    //String cleaner, just removes a number of characters from the front of the string.
+    //http://docs.oracle.com/javase/7/docs/api/java/lang/StringBuffer.html#delete%28int,%20int%29
+    private static String removeChars(String s, int num) {
+        StringBuffer buf = new StringBuffer(s);
+        int front = 0;
+        //Simple error checking. To avoid exception below (this is just a wrapper function around String Buffer's delete() function)
+        //StringIndexOutOfBoundsException - if start is negative, greater than length(), or greater than end.
+       if (num < s.length()) {
+           buf.delete(front,num-1);
+       }
+        return buf.toString();
     }
 
     //Getters and Setters NOT USED CURRENTLY

--- a/AndroidProject/Biometrix/biometrixApp/src/main/java/com/rocket/biometrix/ExerciseEntry.java
+++ b/AndroidProject/Biometrix/biometrixApp/src/main/java/com/rocket/biometrix/ExerciseEntry.java
@@ -153,21 +153,27 @@ public class ExerciseEntry extends AppCompatActivity implements AdapterView.OnIt
                 //Make string array to hold all the strings extracted from the user's input on this entry activity
                 String[] exerciseEntryData = {titleString,dateString,timeString,repsString,weightString,notesString};
 
-                //Put string array that has all the entries data points in it into a Bundle.
+                //Put string array that has all the entries data points in it into a Bundle. This bundle is for future extensibility it is NOT for the parent class.
                 Bundle exerciseEntryBundle = new Bundle();
                 exerciseEntryBundle.putStringArray("exEntBundKey",exerciseEntryData);
 
 
-//                //TODO:Recieve intent extras from parent. Change the old String array to the newly filled string array; then put extra BACK IN and set result to OK w/ error checking.
-//                String parentExerciseEntryData;
-//
-//                    Bundle extras = getIntent().getExtras();
-//                    if(extras == null) {
-//                        parentExerciseEntryData= null;
-//                    } else {
-//                        parentExerciseEntryData= extras.getString("key");
-//                    }
+                //TODO:Recieve intent extras from parent. Change the old String array to the newly filled string array; then put extra BACK IN and set result to OK w/ error checking.
+                Bundle parentExtras = getIntent().getExtras();
+                String[] usersEntryData = parentExtras.getStringArray("parentArray");
 
+
+                //Here is where the parent bundle could be used (to auto-populate an entry for editing for example) For now I will only set the parent's string array equal to exerciseEntryData.
+                usersEntryData = exerciseEntryData;
+
+//                Intent backtoParent = getIntent();
+//
+//                String msg = backtoParent.getStringExtra("key");
+//                if (msg.contentEquals("key")) {
+//                    backtoParent.putExtra("widthInfo", s);
+//                    setResult(RESULT_OK, backtoParent);
+//                    finish();
+//                }
 
                 //TODO: SQLite calls to LocalStorageAccess which will have to be made more abstract first since it's hardcoded now.
 

--- a/AndroidProject/Biometrix/biometrixApp/src/main/java/com/rocket/biometrix/ExerciseEntry.java
+++ b/AndroidProject/Biometrix/biometrixApp/src/main/java/com/rocket/biometrix/ExerciseEntry.java
@@ -1,5 +1,6 @@
 package com.rocket.biometrix;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
@@ -7,6 +8,10 @@ import android.view.View;
 import android.widget.Adapter;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.RadioButton;
+import android.widget.RadioGroup;
 import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -16,8 +21,12 @@ public class ExerciseEntry extends AppCompatActivity implements AdapterView.OnIt
     Spinner minuteSpinner;
     boolean toasted = false; //Used to display encouraging messages ONCE in minuteSpinner.
 
-    public static TextView timeTV;
+    public static TextView timeTV; //Used by the DateTimePopulateTextView in the onCreate event
     public static TextView dateTV;
+
+    String min_selected; //string to save minutes exercised spinner result
+    String type_selected; //string to save type of exercise selected in the radio 'bubble' buttons
+
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -45,10 +54,10 @@ public class ExerciseEntry extends AppCompatActivity implements AdapterView.OnIt
                     initializedAdapter = parentView.getAdapter();
                     return;
                 }
+                //Set string
+                min_selected = parentView.getItemAtPosition(position).toString();
 
-                String selected = parentView.getItemAtPosition(position).toString();
-
-                if (selected.equals("5") || selected.equals("10")) {
+                if (min_selected.equals("5") || min_selected.equals("10")) {
                     if (!toasted) {
                         Toast.makeText(getApplicationContext(), "Keep it up :)", Toast.LENGTH_LONG).show();
                         toasted = true;
@@ -70,9 +79,38 @@ public class ExerciseEntry extends AppCompatActivity implements AdapterView.OnIt
             }
         });
 
-        //@Corrections for 'next' ime button //I'm too stupid to figure out how to use.
-//        TextView nextField = (TextView)currentField.focusSearch(View.FOCUS_RIGHT);
-//        nextField.requestFocus();
+        //Group of exercise types in the right corner, like "cardio"
+        RadioGroup rg = (RadioGroup) findViewById(R.id.ex_radioGroup);
+        //When a bubble is poked, update a string to match the bubble poked.
+        rg.setOnCheckedChangeListener(new RadioGroup.OnCheckedChangeListener() {
+            public void onCheckedChanged(RadioGroup group, int checkedId) {
+                switch (checkedId) {
+                    case R.id.ex_rb_a:
+                        //Extract CharSequences from UI and convert them to string array
+                        final RadioButton ETa1 = (RadioButton) findViewById(R.id.ex_rb_a);
+                        type_selected = ETa1.getText().toString();
+                        break;
+
+                    case R.id.ex_rb_b:
+                        final RadioButton ETa2 = (RadioButton) findViewById(R.id.ex_rb_b);
+                        type_selected = ETa2.getText().toString();
+                        break;
+
+                    case R.id.ex_rb_c:
+                        final RadioButton ETa3 = (RadioButton) findViewById(R.id.ex_rb_c);
+                        type_selected = ETa3.getText().toString();
+                        break;
+
+                    case R.id.ex_rb_d:
+                        final RadioButton ETa4 = (RadioButton) findViewById(R.id.ex_rb_d);
+                        type_selected = ETa4.getText().toString();
+                        break;
+
+                }
+
+
+            }
+        });
 
         //Linking contexts likes non-null variables.
         timeTV = (TextView) findViewById(R.id.ex_tv_time);
@@ -80,7 +118,23 @@ public class ExerciseEntry extends AppCompatActivity implements AdapterView.OnIt
 
         //Slick calls to fill date and time textviews.
         DateTimePopulateTextView DTPOWAH = new DateTimePopulateTextView(ExerciseEntry.this, R.id.ex_tv_date, R.id.ex_tv_time);
-        DTPOWAH.Populate();
+        DTPOWAH.Populate(); //Change the text
+
+
+        //Done click event saves entered data to string array
+        //Bundles string array for transport across activities
+        //Saves entry to SQLlite DB using LocalStorageAccess
+        //And, Adds this exercise to the 'plan' if it needs to be added
+        //Lastly, it closes up the entry activity.
+        Button addNewEntry = (Button) findViewById(R.id.ex_b_done);
+        addNewEntry.setOnClickListener(new View.OnClickListener() {
+            public void onClick(View v) {
+
+
+                //Kill this thread, User will still have exercise main page open.
+                finish();
+            }
+        }); //end addNewEntry on click listener
 
     }//END onCreate()
 
@@ -92,32 +146,30 @@ public class ExerciseEntry extends AppCompatActivity implements AdapterView.OnIt
     @Override
     public void onNothingSelected(AdapterView<?> parent) {
         //To please the cruel mistress Android Studio...
-        //O! Foul bits! My tongue will tell the anger of my heart,
-        // or else my heart concealing it will break.
     }
 
-    //Getters and Setters NEVER USED
+    //Getters and Setters NOT USED CURRENTLY
 
     //Setter for time TextView
-public void setTimeText (String time){
-    timeTV = (TextView)findViewById(R.id.ex_tv_time);
-    timeTV.setText(time);
-}
-    //Setter for date TextView
-    public void setDateText (String date){
-        TextView dateTV = (TextView)findViewById(R.id.ex_tv_date);
-        dateTV.setText(date);
-    }
-
-    //Getter for time TextView
-    public TextView getTimeText (){
-        TextView timeTV = (TextView)findViewById(R.id.ex_tv_time);
-        return timeTV;
-    }
-    //Getter for date TextView
-    public TextView getDateText () {
-        TextView dateTV = (TextView) findViewById(R.id.ex_tv_date);
-        return dateTV;
-    }
+//public void setTimeText (String time){
+//    timeTV = (TextView)findViewById(R.id.ex_tv_time);
+//    timeTV.setText(time);
+//}
+//    //Setter for date TextView
+//    public void setDateText (String date){
+//        TextView dateTV = (TextView)findViewById(R.id.ex_tv_date);
+//        dateTV.setText(date);
+//    }
+//
+//    //Getter for time TextView
+//    public TextView getTimeText (){
+//        TextView timeTV = (TextView)findViewById(R.id.ex_tv_time);
+//        return timeTV;
+//    }
+//    //Getter for date TextView
+//    public TextView getDateText () {
+//        TextView dateTV = (TextView) findViewById(R.id.ex_tv_date);
+//        return dateTV;
+//    }
 
 }

--- a/AndroidProject/Biometrix/biometrixApp/src/main/java/com/rocket/biometrix/ExerciseParent.java
+++ b/AndroidProject/Biometrix/biometrixApp/src/main/java/com/rocket/biometrix/ExerciseParent.java
@@ -33,13 +33,42 @@ public class ExerciseParent extends AppCompatActivity {
         Button addNewEntry = (Button) findViewById(R.id.exNewEntry);
         addNewEntry.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
-                //start new intent (Parent activity start with capital, child don't have capital)
+                //start new intent
                 Intent LaunchNewEntry = new Intent(ExerciseParent.this, ExerciseEntry.class);
-                //start new activity
-                startActivity(LaunchNewEntry);
-                //finish();
+
+                //put extra data for ExerciseEntry to use
+                //http://stackoverflow.com/questions/5265913/how-to-use-putextra-and-getextra-for-string-data
+                //http://www.mybringback.com/android-sdk/12204/onactivityresult-android-tutorial/
+                String[] usersEntryData = null; //will be filled up by ExerciseEntry on its finish();
+
+                //key is a reference to the data im putting in the intent.
+                LaunchNewEntry.putExtra("key", usersEntryData);
+
+                //Way to check if user actually put in an entry or accidentally tapped it.
+                startActivityForResult(LaunchNewEntry, 1);
+
+                //Why is JP doing this? For future extensibility, this will have to be done to edit past entries. (to autopopulate entry with original data)
+                //TODO: Receive with error checking the finish() intent of ExerciseEntry, display toast message w/ title
+
+
             }
         }); //end addNewEntry on click listener
+
+        //Automated class for this garbage.
+        //TODO: https://github.com/beplaya/Wagon convince group to be truly open source warriors
+
+
+
+
+
+        //we need a handler for when the secondary activity finishes it's work
+        //and returns control to this activity...
+//        @Override
+//        protected void onActivityResult(int requestCode, int resultCode, Intent intent){
+//            super.onActivityResult(requestCode, resultCode, intent);
+//            Bundle extras = intent.getExtras();
+//            mEditText1.setText(extras != null ? extras.getString("returnKey"):"nothing returned");
+//        }
 
     } //end OnCreate of ExerciseParent
 }

--- a/AndroidProject/Biometrix/biometrixApp/src/main/java/com/rocket/biometrix/ExerciseParent.java
+++ b/AndroidProject/Biometrix/biometrixApp/src/main/java/com/rocket/biometrix/ExerciseParent.java
@@ -6,8 +6,12 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.view.View;
 import android.widget.Button;
+import android.widget.Toast;
 
 public class ExerciseParent extends AppCompatActivity {
+
+    static final int ADD_ENTRY_REQUEST = 1;
+    String[] usersEntryData = null; //will be filled up by ExerciseEntry on its finish();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -29,7 +33,6 @@ public class ExerciseParent extends AppCompatActivity {
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
 
-
         Button addNewEntry = (Button) findViewById(R.id.exNewEntry);
         addNewEntry.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
@@ -39,11 +42,9 @@ public class ExerciseParent extends AppCompatActivity {
                 //put extra data for ExerciseEntry to use
                 //http://stackoverflow.com/questions/5265913/how-to-use-putextra-and-getextra-for-string-data
                 //http://www.mybringback.com/android-sdk/12204/onactivityresult-android-tutorial/
-                String[] usersEntryData = null; //will be filled up by ExerciseEntry on its finish();
-
                 //Bundling the empty usersEntryData to be filled. This seems redundant NOW but later, it will make life easier.
                 Bundle usrEntD = new Bundle();
-                usrEntD.putStringArray("parentArray",usersEntryData);
+                usrEntD.putStringArray("parentArray", usersEntryData);
 
                 //key is a reference to the data im putting in the intent. Which is the bundle created above.
                 LaunchNewEntry.putExtra("key", usrEntD);
@@ -58,21 +59,27 @@ public class ExerciseParent extends AppCompatActivity {
             }
         }); //end addNewEntry on click listener
 
-        //Automated class for this garbage.
-        //TODO: https://github.com/beplaya/Wagon convince group to be truly open source warriors
-
-
-
-
-
-        //we need a handler for when the secondary activity finishes it's work
-        //and returns control to this activity...
-//        @Override
-//        protected void onActivityResult(int requestCode, int resultCode, Intent intent){
-//            super.onActivityResult(requestCode, resultCode, intent);
-//            Bundle extras = intent.getExtras();
-//            mEditText1.setText(extras != null ? extras.getString("returnKey"):"nothing returned");
-//        }
 
     } //end OnCreate of ExerciseParent
+
+    //Automated class for this garbage.
+    //TODO: https://github.com/beplaya/Wagon convince group to be truly open source warriors
+
+    //Automatically called
+    //http://developer.android.com/reference/android/app/Activity.html
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == ADD_ENTRY_REQUEST) {
+            if (resultCode == RESULT_OK) {
+                if (data.getExtras().containsKey("childKey")) {
+                    usersEntryData = data.getBundleExtra("childKey").getStringArray("childKey");
+                    //Lil bling bling to let user know they successfully saved an entry.
+                    Toast.makeText(getApplicationContext(), "Added entry: " + usersEntryData[0], Toast.LENGTH_SHORT).show();
+                }
+            }
+        }// end request code check
+    }
+
+
 }

--- a/AndroidProject/Biometrix/biometrixApp/src/main/java/com/rocket/biometrix/ExerciseParent.java
+++ b/AndroidProject/Biometrix/biometrixApp/src/main/java/com/rocket/biometrix/ExerciseParent.java
@@ -41,8 +41,12 @@ public class ExerciseParent extends AppCompatActivity {
                 //http://www.mybringback.com/android-sdk/12204/onactivityresult-android-tutorial/
                 String[] usersEntryData = null; //will be filled up by ExerciseEntry on its finish();
 
-                //key is a reference to the data im putting in the intent.
-                LaunchNewEntry.putExtra("key", usersEntryData);
+                //Bundling the empty usersEntryData to be filled. This seems redundant NOW but later, it will make life easier.
+                Bundle usrEntD = new Bundle();
+                usrEntD.putStringArray("parentArray",usersEntryData);
+
+                //key is a reference to the data im putting in the intent. Which is the bundle created above.
+                LaunchNewEntry.putExtra("key", usrEntD);
 
                 //Way to check if user actually put in an entry or accidentally tapped it.
                 startActivityForResult(LaunchNewEntry, 1);

--- a/AndroidProject/Biometrix/biometrixApp/src/main/res/layout/content_exercise_entry.xml
+++ b/AndroidProject/Biometrix/biometrixApp/src/main/res/layout/content_exercise_entry.xml
@@ -53,31 +53,31 @@
         android:layout_row="0"
         android:layout_column="1"
         android:layout_marginLeft="260dp"
-        android:id="@+id/radioGroup"
+        android:id="@+id/ex_radioGroup"
         android:layout_marginTop="80dp">
 
         <RadioButton
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Light"
+            android:text="@string/ex_rb_a_t"
             android:id="@+id/ex_rb_a" />
 
         <RadioButton
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Cardio"
+            android:text="@string/ex_rb_b_t"
             android:id="@+id/ex_rb_b" />
 
         <RadioButton
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Strength"
+            android:text="@string/ex_rb_c_t"
             android:id="@+id/ex_rb_c" />
 
         <RadioButton
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Heavy"
+            android:text="@string/ex_rb_d_t"
             android:id="@+id/ex_rb_d" />
     </RadioGroup>
 
@@ -166,7 +166,7 @@
         android:layout_alignParentStart="true"
         android:hint="Notes:"
         android:text="@string/ex_et_notes"
-        android:layout_alignEnd="@+id/radioGroup"
+        android:layout_alignEnd="@+id/ex_radioGroup"
         android:layout_marginTop="20dp"
         />
 

--- a/AndroidProject/Biometrix/biometrixApp/src/main/res/values/exer_strings.xml
+++ b/AndroidProject/Biometrix/biometrixApp/src/main/res/values/exer_strings.xml
@@ -4,13 +4,9 @@
     <!--Exercise Module Strings-->
     <string name="newEntryButton">+ Add Exercise</string>
 
-    <!--Add New Entry-->
+    <!--Add New Entry Styling-->
     <string name="title_activity_exercise__entry_fs">exercise_EntryFS</string>
     <string name="ex_ok">D O N E</string>
-    <string name="ex_et_title"> </string>
-    <string name="ex_et_notes"> </string>
-    <string name="ex_et_reps"> </string>
-    <string name="ex_et_weight"> </string>
     <string name="ex_time">Minutes:</string>
     <string name="ex_prompt">How many minutes Exercised? :)</string>
     <string-array name="ex_min_array">
@@ -32,8 +28,17 @@
     <string name="ex_update">Logging Exercise at This Time:</string>
     <string name="ex_tp">Time:</string>
     <string name="ex_dp">Date:</string>
-
     <string name="ex_date"> </string>
+    <string name="ex_rb_a_t">Light</string>
+    <string name="ex_rb_b_t">Cardio</string>
+    <string name="ex_rb_c_t">Strength</string>
+    <string name="ex_rb_d_t">Heavy</string>
+
+    <!--Add new Entry's User Input-->
+    <string name="ex_et_title"> </string>
+    <string name="ex_et_notes"> </string>
+    <string name="ex_et_reps"> </string>
+    <string name="ex_et_weight"> </string>
 
     <!--Default full screen-->
     <string name="dummy_button">placeholder</string>


### PR DESCRIPTION
### Summary
ExerciseParent now sends a string array to ExerciseEntry which is sent back filled with strings that represent the self-reported data points on the entry page (such as exercise title) when DONE is tapped. 
### What code was added?
The code I have added consists of: A few helper functions like GetStringFromEditText, which is useful across the entire app; bundling of the ExerciseEntry's string array for export/import with some points of extension that seem redundant now (see comments); and onActivityResult() methods that are extendable to future error checking (right now, it just displays the entries title on ExerciseParent after the entry's 'done' button has been clicked).
### What resources were added?
The resources I have added are a few radio button string resources, since their titles were hard-coded before.

### Why not just pass a string array back to parent in the simplest way? Your code seems redundant and overly complicated...
All the error checking, and the multiple bundles exist so that in the future, it will be much easier to extend the functionality of the Exercise x classes. For example, a bundle with an empty string array is sent to ExerciseEntry, even though it isn't necessary. This is so it will be easier to edit a past entry once that class has been built (the entry activity could be auto-populated). I have done my best to comment in the code where these areas are and cite examples of possible future uses for the extra code that seems redundant NOW.

